### PR TITLE
Changes the way membership dates are updated...

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,8 +2,9 @@
 /**
  * Plugin Name: Empire Tri Club Memberships
  * Author: Jean Kim
- * Version: 1.0.0
- *
+ * Plugin URI: https://github.com/jeanyoungkim/empire-tri-club-memberships
+ * Description: Allows membership start and end dates with WooCommerce Memberships
+ * Version: 1.1.0
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -14,15 +15,56 @@ require( 'metabox.php' );
 
 add_action( 'save_post', function($post_id) {
     $post = get_post($post_id);
+defined( 'ABSPATH' ) or exit; // Exit if accessed directly
+
+
+class ETC_Memberships {
+	
+	
+	/** @var ETC_Memberships single instance of this plugin */
+	protected static $instance;
+	
+	
+	
+	/** Helper methods ***************************************/
+	
+	
+	/**
+	 * Main ETC_Memberships Instance, ensures only one instance is/can be loaded
+	 *
+	 * @since 1.0.0
+	 * @see etc_memberships()
+	 * @return ETC_Memberships
+ 	*/
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+	
 
     if ( $post->post_type != 'wc_user_membership' ) return;
 
     $user_membership = wc_memberships_get_user_membership( $post );
     $plan = get_post( $user_membership->get_plan_id() );
+} // end \ETC_Memberships class
+
+
+/**
+ * Returns the One True Instance of ETC_Memberships
+ *
+ * @since 1.0.0
+ * @return ETC_Memberships
+ */
+function etc_memberships() {
+    return ETC_Memberships::instance();
+}
 
     $start_date = get_post_meta( $plan->ID, '_etc_memberships_start_date', true );
     $end_date = get_post_meta( $plan->ID, '_etc_memberships_end_date', true );
 
     update_post_meta( $post->ID, '_start_date', $start_date );
     update_post_meta( $post->ID, '_end_date', $end_date );
-}, 100, 2);
+}, 100, 2);// fire it up!
+etc_memberships();

--- a/index.php
+++ b/index.php
@@ -92,17 +92,17 @@ class ETC_Memberships {
 
 		$user_membership = wc_memberships_get_user_membership( $args['user_membership_id'] );
 
-    	$start_date = get_post_meta( $plan->get_id(), '_etc_memberships_start_date', true );
-    	$end_date = get_post_meta( $plan->get_id(), '_etc_memberships_end_date', true );
+		$start_date = get_post_meta( $plan->get_id(), '_etc_memberships_start_date', true );
+		$end_date = get_post_meta( $plan->get_id(), '_etc_memberships_end_date', true );
 
 		// only update post meta if these values are set
-    	if ( ! empty( $start_date ) ) {
-    		update_post_meta( $user_membership->get_id(), '_start_date', $start_date );
-    	}
+		if ( ! empty( $start_date ) ) {
+			update_post_meta( $user_membership->get_id(), '_start_date', $start_date );
+		}
     
-    	if ( ! empty( $end_date ) ) {
-    		update_post_meta( $user_membership->get_id(), '_end_date', $end_date );
-    	}
+		if ( ! empty( $end_date ) ) {
+			update_post_meta( $user_membership->get_id(), '_end_date', $end_date );
+		}
 	}
 
 } // end \ETC_Memberships class


### PR DESCRIPTION
...to ensure the update occurs at _purchase_ rather than requiring a save to update the new membership's dates. Allows updates to the membership as well so admins can manually adjust these dates if desired.

@jeanyoungkim wasn’t sure if perhaps a filter around allowing renewals / extensions would be helpful or not — i.e. this could let you block time extensions from renewals if you didn’t want to allow any changes to the end date at all. Would just need to remove / filter the part where `modify_dates()` bails in the beginning :)
